### PR TITLE
Fix class-inheritance and package lookup in go-to-definition and completion

### DIFF
--- a/demo/class_inheritance_definition.sv
+++ b/demo/class_inheritance_definition.sv
@@ -1,0 +1,19 @@
+// Parent/child class fixture for go-to-definition testing.
+// pkt_base (pkt_base.sv) and pkt_child (pkt_child.sv) are separate project
+// files, listed in vcode.f as extra files.
+//
+// Open this file in Neovim and go-to-def on `depth` and `apply` in
+// `child.depth` / `child.apply()` below. Both are declared only on the
+// parent `pkt_base`, not on `pkt_child` itself.
+//
+// Go-to-def walks the `extends` chain, so both jumps land on the declarations
+// in `pkt_base`.
+
+module class_inheritance_definition_demo;
+    pkt_child child;
+
+    initial begin
+        child.depth = 1;
+        child.apply();
+    end
+endmodule

--- a/demo/common_pkg.sv
+++ b/demo/common_pkg.sv
@@ -1,0 +1,6 @@
+package common_pkg;
+typedef int my_int_t;
+
+function void foo();
+endfunction
+endpackage

--- a/demo/pkg_use.sv
+++ b/demo/pkg_use.sv
@@ -1,0 +1,9 @@
+module top;
+import common_pkg::*;
+
+my_int_t                                x                                   ; // ← Go to Definition
+
+initial begin
+    foo(); // ← Go to Definition
+end
+endmodule

--- a/demo/pkt_base.sv
+++ b/demo/pkt_base.sv
@@ -1,0 +1,9 @@
+// Parent class for the class-inheritance go-to-def demo.
+// See class_inheritance_definition.sv for the fixture that exercises this.
+
+class pkt_base;
+    int depth;
+
+    function void apply();
+    endfunction
+endclass

--- a/demo/pkt_child.sv
+++ b/demo/pkt_child.sv
@@ -1,0 +1,14 @@
+// Child class for the class-inheritance go-to-def demo.
+// Extends pkt_base (pkt_base.sv). See class_inheritance_definition.sv for
+// the fixture that exercises this.
+
+class pkt_child extends pkt_base;
+    int extra_field;
+
+    // Go-to-def on `depth` here jumps to `pkt_base::depth` --
+    // this is inherited field access from inside the child class body,
+    // not external `obj.field` access.
+    function void bump();
+        depth = depth + 1;
+    endfunction
+endclass

--- a/demo/vcode.f
+++ b/demo/vcode.f
@@ -10,3 +10,7 @@
 ./uvm-core/src/uvm_pkg.sv
 ./uvm_completion_demo.sv
 ./uvm_autocomplete_test.sv
+./pkt_base.sv
+./pkt_child.sv
+./common_pkg.sv
+./pkg_use.sv

--- a/src/analyzer.cpp
+++ b/src/analyzer.cpp
@@ -1737,6 +1737,52 @@ static std::optional<Location> find_class_member_definition(const SyntaxIndex& i
     return std::nullopt;
 }
 
+// One SyntaxIndex shard plus the URI to fall back on when the shard carries no
+// source file of its own.  Class hierarchies routinely span shards — a child in
+// the current file extending a base in a closed project file — so member lookup
+// has to be able to hop between them.
+struct ClassLookupShard {
+    const SyntaxIndex* index;
+    const std::string* uri;
+};
+
+static const ClassEntry* find_class_entry(const SyntaxIndex& index, std::string_view class_name) {
+    auto it = index.class_by_name.find(std::string(class_name));
+    if (it == index.class_by_name.end() || it->second >= index.classes.size())
+        return nullptr;
+    return &index.classes[it->second];
+}
+
+// Resolve `member_name` on `class_name`, then on its `extends` ancestors.
+//
+// SystemVerilog inherits properties and methods, so `child.depth` and a bare
+// `depth` inside a child class body both have to reach `pkt_base::depth`.  Each
+// hop re-searches every shard because the base class is frequently declared in
+// a different file than the child.
+static std::optional<Location> find_class_member_in_hierarchy(
+    std::span<const ClassLookupShard> shards, std::string class_name,
+    std::string_view member_name) {
+    std::unordered_set<std::string> visited;
+    while (!class_name.empty() && visited.insert(class_name).second) {
+        for (const auto& shard : shards) {
+            if (auto loc = find_class_member_definition(*shard.index, *shard.uri, class_name,
+                                                        member_name))
+                return loc;
+        }
+
+        std::string base;
+        for (const auto& shard : shards) {
+            const auto* cls = find_class_entry(*shard.index, class_name);
+            if (cls && !cls->base_class.empty()) {
+                base = base_class_lookup_name(cls->base_class);
+                break;
+            }
+        }
+        class_name = std::move(base);
+    }
+    return std::nullopt;
+}
+
 static bool token_at_location(const slang::SourceManager& sm, const slang::parsing::Token& token,
                               const Location& location) {
     if (!token || !token.location().valid())
@@ -2124,6 +2170,9 @@ struct DefinitionTarget {
     std::string package_qualifier;
     std::string scope_module;
     std::string scope_package;
+    // Innermost class body the cursor sits in, empty outside class scope.
+    // Unqualified names there may be inherited members.
+    std::string scope_class;
 };
 
 struct DefinitionTargetVisitor : public slang::syntax::SyntaxVisitor<DefinitionTargetVisitor> {
@@ -2134,6 +2183,7 @@ struct DefinitionTargetVisitor : public slang::syntax::SyntaxVisitor<DefinitionT
     DefinitionTarget target;
     std::string current_module;
     std::string current_package;
+    std::string current_class;
 
     DefinitionTargetVisitor(const slang::SourceManager& sm, const std::string& uri, int line,
                             int col)
@@ -2181,6 +2231,15 @@ struct DefinitionTargetVisitor : public slang::syntax::SyntaxVisitor<DefinitionT
         visitDefault(node);
         current_module = std::move(previous_module);
         current_package = std::move(previous_package);
+    }
+
+    // Tracked so an unqualified name inside a class body can be resolved
+    // against that class and the classes it extends.
+    void handle(const slang::syntax::ClassDeclarationSyntax& node) {
+        auto previous_class = current_class;
+        current_class = std::string(node.name.valueText());
+        visitDefault(node);
+        current_class = std::move(previous_class);
     }
 
     void handle(const slang::syntax::HierarchyInstantiationSyntax& node) {
@@ -2380,6 +2439,7 @@ struct DefinitionTargetVisitor : public slang::syntax::SyntaxVisitor<DefinitionT
             target.name = std::string(token.valueText());
             target.scope_module = current_module;
             target.scope_package = current_package;
+            target.scope_class = current_class;
         }
     }
 };
@@ -2927,6 +2987,18 @@ Analyzer::definition_of_state(const DocumentState& state, const std::string& uri
     const int use_line_one_based = line + 1;
     const auto& current_index = get_structural_index(state);
 
+    // Every shard a class hierarchy could be spread across, current file first.
+    auto class_lookup_shards = [&] {
+        std::vector<ClassLookupShard> shards;
+        shards.reserve(extra_files.size() + 1);
+        shards.push_back(ClassLookupShard{&current_index, &uri});
+        for (const auto& extra : extra_files) {
+            if (!skip_extra(extra))
+                shards.push_back(ClassLookupShard{&extra.index_ref(), &extra.uri});
+        }
+        return shards;
+    };
+
     if (target.kind == DefinitionTargetKind::PackageMember) {
         if (auto loc =
                 find_package_member(current_index, uri, target.package_qualifier, target.name))
@@ -2971,18 +3043,16 @@ Analyzer::definition_of_state(const DocumentState& state, const std::string& uri
         if (class_type) {
             // The object type may name either a class or a typedef'd aggregate.
             // Search both compact index families so `obj.field` works for
-            // closed-file classes as well as structs/unions.
-            if (auto loc =
-                    find_class_member_definition(current_index, uri, *class_type, target.name))
+            // closed-file classes as well as structs/unions.  Class lookup
+            // walks the `extends` chain; typedef aggregates have no base type.
+            const auto shards = class_lookup_shards();
+            if (auto loc = find_class_member_in_hierarchy(shards, *class_type, target.name))
                 return loc;
             if (auto loc = find_typedef_field_definition(current_index, uri, *class_type, target.name))
                 return loc;
             for (const auto& extra : extra_files) {
                 if (skip_extra(extra))
                     continue;
-                if (auto loc = find_class_member_definition(extra.index_ref(), extra.uri, *class_type,
-                                                            target.name))
-                    return loc;
                 if (auto loc = find_typedef_field_definition(extra.index_ref(), extra.uri,
                                                              *class_type, target.name))
                     return loc;
@@ -2998,6 +3068,25 @@ Analyzer::definition_of_state(const DocumentState& state, const std::string& uri
                                            target.scope_package, visible_imports,
                                            use_line_one_based))
         return loc;
+
+    // An unqualified name inside a class body that the current file cannot
+    // explain may be an inherited member:
+    //
+    //     class pkt_child extends pkt_base;
+    //         function void bump();
+    //             depth = depth + 1;   // pkt_base::depth, declared elsewhere
+    //
+    // This runs after the current-file walk so method locals and same-file
+    // declarations keep shadowing the base class, and before the project-wide
+    // generic scan so an unrelated same-named symbol cannot win over a real
+    // inherited member.
+    if (!target.scope_class.empty()) {
+        if (auto loc =
+                find_class_member_in_hierarchy(class_lookup_shards(), target.scope_class,
+                                               target.name))
+            return loc;
+    }
+
     for (const auto& extra : extra_files) {
         if (skip_extra(extra))
             continue;

--- a/src/dynamic_file_index.cpp
+++ b/src/dynamic_file_index.cpp
@@ -575,14 +575,29 @@ void process_package(const ModuleDeclarationSyntax& pkg, SyntaxIndex& index,
                 }
             }
         } else if (const auto* fn = member->as_if<FunctionDeclarationSyntax>()) {
-            const auto name = node_text_raw(sm, *fn->prototype->name);
+            // Mirrors the package branch in syntax_index.cpp.  The entry must
+            // carry the declaration position: without it go-to-definition on an
+            // imported package subroutine lands on line 0 / column 0 whenever
+            // the package file happens to be open in the editor, because the
+            // open buffer is answered from this shard instead of the
+            // disk-backed one.
+            const auto& proto = *fn->prototype;
+            const auto* id_name = proto.name->as_if<IdentifierNameSyntax>();
+            const auto name_tok = id_name ? id_name->identifier : proto.keyword;
+            const auto name = id_name ? std::string(id_name->identifier.valueText())
+                                      : node_text_raw(sm, *proto.name);
+            auto [nl, nc] = token_pos_line1_col0(sm, name_tok);
             index.package_value_by_scoped_name.try_emplace(
                 package_scoped_key(module.name, name), index.values.size());
-            index.values.push_back(ValueEntry{.name = name,
-                                              .type = node_text_raw(sm, *fn->prototype->returnType),
-                                              .kind = "function",
-                                              .parent_scope = module.name,
-                                              .file_id = resolver.for_token(index, sm, fn->prototype->keyword)});
+            index.values.push_back(
+                ValueEntry{.name = name,
+                           .type = node_text_raw(sm, *proto.returnType),
+                           .kind = token_value_text(proto.keyword),
+                           .parent_scope = module.name,
+                           .file_id = resolver.for_token(index, sm, name_tok),
+                           .line = nl,
+                           .col = nc,
+                           .signature = make_subroutine_signature(proto, name, sm)});
             index.package_symbols[module.name].push_back(name);
         } else if (const auto* cls = member->as_if<ClassDeclarationSyntax>()) {
             process_class(*cls, index, resolver, sm, module.name);

--- a/src/features/completion.cpp
+++ b/src/features/completion.cpp
@@ -836,6 +836,13 @@ static std::string completion_base_type_name(std::string type) {
     const size_t paren = type.find("#(");
     if (paren != std::string::npos)
         type.erase(paren);
+    // A package qualifier has to go before the leading-identifier scan below,
+    // which would otherwise reduce `cfg_pkg::base_cfg` to the package name and
+    // make every class lookup on that type miss.  The scan itself must stay
+    // leading-component so ordinary declarations such as `logic [7:0]` still
+    // reduce to `logic`.
+    if (const size_t scope = type.rfind("::"); scope != std::string::npos)
+        type.erase(0, scope + 2);
     type = trim_completion_copy(std::move(type));
     size_t end = 0;
     while (end < type.size() && is_ident_char(type[end]))
@@ -1513,12 +1520,8 @@ current_file_member_access_items_from_ast(const DocumentState& state, const Comp
                     return;
                 }
                 if (node.extendsClause) {
-                    // completion_base_type_name() stops at the first non-identifier
-                    // character, so a package-qualified base (`extends
-                    // cfg_pkg::base_cfg`) would reduce to the package name.  Drop
-                    // the qualifier and any parameter overrides first.
-                    emit_class(completion_base_type_name(base_class_lookup_name(
-                        current_ast_decl_text(*node.extendsClause->baseName))));
+                    emit_class(completion_base_type_name(
+                        current_ast_decl_text(*node.extendsClause->baseName)));
                 }
                 for (const auto* item : node.items) {
                     if (const auto* prop = item ? item->as_if<ClassPropertyDeclarationSyntax>() : nullptr) {

--- a/src/features/completion.cpp
+++ b/src/features/completion.cpp
@@ -1,5 +1,6 @@
 #include "completion.hpp"
 #include "../syntax_index.hpp"
+#include "../syntax_index_shared.hpp"
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
@@ -1511,8 +1512,14 @@ current_file_member_access_items_from_ast(const DocumentState& state, const Comp
                     visitDefault(node);
                     return;
                 }
-                if (node.extendsClause)
-                    emit_class(completion_base_type_name(current_ast_decl_text(*node.extendsClause->baseName)));
+                if (node.extendsClause) {
+                    // completion_base_type_name() stops at the first non-identifier
+                    // character, so a package-qualified base (`extends
+                    // cfg_pkg::base_cfg`) would reduce to the package name.  Drop
+                    // the qualifier and any parameter overrides first.
+                    emit_class(completion_base_type_name(base_class_lookup_name(
+                        current_ast_decl_text(*node.extendsClause->baseName))));
+                }
                 for (const auto* item : node.items) {
                     if (const auto* prop = item ? item->as_if<ClassPropertyDeclarationSyntax>() : nullptr) {
                         if (const auto* data = prop->declaration->as_if<DataDeclarationSyntax>()) {
@@ -1892,7 +1899,10 @@ class MemberProvider : public CompletionProvider {
                 if (!visited_classes.insert(cls.name).second)
                     return; // cycle or diamond — stop
                 if (!cls.base_class.empty()) {
-                    if (const auto base_it = index.class_by_name.find(cls.base_class);
+                    // The clause is stored verbatim, so `extends pkg::base #(8)`
+                    // has to be reduced to `base` before it can be looked up.
+                    if (const auto base_it =
+                            index.class_by_name.find(base_class_lookup_name(cls.base_class));
                         base_it != index.class_by_name.end())
                         add_class_members(index.classes[base_it->second]);
                 }

--- a/src/syntax_index.cpp
+++ b/src/syntax_index.cpp
@@ -16,53 +16,6 @@
 using namespace slang;
 using namespace slang::syntax;
 
-static std::string make_fn_signature(const FunctionPrototypeSyntax& proto,
-                                     const std::string& name,
-                                     const slang::SourceManager& sm) {
-    const bool is_task =
-        proto.keyword.kind == slang::parsing::TokenKind::TaskKeyword;
-    const std::string ports =
-        proto.portList ? trim_copy(proto.portList->toString()) : "";
-
-    std::string formatted_ports;
-    if (ports.size() >= 2 && ports.front() == '(' && ports.back() == ')') {
-        auto inner = trim_copy(ports.substr(1, ports.size() - 2));
-        if (inner.empty()) {
-            formatted_ports = "()";
-        } else {
-            std::vector<std::string> parts;
-            size_t start = 0;
-            while (start <= inner.size()) {
-                auto comma = inner.find(',', start);
-                if (comma == std::string::npos) {
-                    parts.push_back(trim_copy(inner.substr(start)));
-                    break;
-                }
-                parts.push_back(trim_copy(inner.substr(start, comma - start)));
-                start = comma + 1;
-            }
-            if (parts.size() <= 1) {
-                formatted_ports = "(" + inner + ")";
-            } else {
-                formatted_ports = "(\n";
-                for (size_t i = 0; i < parts.size(); ++i) {
-                    formatted_ports += "    " + parts[i];
-                    if (i + 1 != parts.size())
-                        formatted_ports += ",\n";
-                }
-                formatted_ports += "\n)";
-            }
-        }
-    } else {
-        formatted_ports = ports;
-    }
-
-    if (is_task)
-        return "```\ntask " + name + formatted_ports + "\n```";
-    const std::string ret = render_syntax_node_text(sm, *proto.returnType);
-    return "```\nfunction " + ret + " " + name + formatted_ports + "\n```";
-}
-
 static std::pair<int, int> source_range_lines(const slang::SourceManager& sm,
                                               slang::SourceRange range) {
     if (!range.start().valid() || !range.end().valid())
@@ -539,7 +492,7 @@ static void process_module(const ModuleDeclarationSyntax& module, SyntaxIndex& i
                 .file_id = resolver.for_token(index, sm, name_tok),
                 .line = nl,
                 .col = nc,
-                .signature = make_fn_signature(proto, fn_name, sm),
+                .signature = make_subroutine_signature(proto, fn_name, sm),
             });
         } else if (const auto* ps = member->as_if<ParameterDeclarationStatementSyntax>()) {
             // Body parameters (`localparam DEPTH = 1;`) as opposed to header

--- a/src/syntax_index_shared.cpp
+++ b/src/syntax_index_shared.cpp
@@ -12,6 +12,53 @@
 using namespace slang;
 using namespace slang::syntax;
 
+std::string make_subroutine_signature(const FunctionPrototypeSyntax& proto,
+                                      const std::string& name,
+                                      const slang::SourceManager& sm) {
+    const bool is_task =
+        proto.keyword.kind == slang::parsing::TokenKind::TaskKeyword;
+    const std::string ports =
+        proto.portList ? trim_copy(proto.portList->toString()) : "";
+
+    std::string formatted_ports;
+    if (ports.size() >= 2 && ports.front() == '(' && ports.back() == ')') {
+        auto inner = trim_copy(ports.substr(1, ports.size() - 2));
+        if (inner.empty()) {
+            formatted_ports = "()";
+        } else {
+            std::vector<std::string> parts;
+            size_t start = 0;
+            while (start <= inner.size()) {
+                auto comma = inner.find(',', start);
+                if (comma == std::string::npos) {
+                    parts.push_back(trim_copy(inner.substr(start)));
+                    break;
+                }
+                parts.push_back(trim_copy(inner.substr(start, comma - start)));
+                start = comma + 1;
+            }
+            if (parts.size() <= 1) {
+                formatted_ports = "(" + inner + ")";
+            } else {
+                formatted_ports = "(\n";
+                for (size_t i = 0; i < parts.size(); ++i) {
+                    formatted_ports += "    " + parts[i];
+                    if (i + 1 != parts.size())
+                        formatted_ports += ",\n";
+                }
+                formatted_ports += "\n)";
+            }
+        }
+    } else {
+        formatted_ports = ports;
+    }
+
+    if (is_task)
+        return "```\ntask " + name + formatted_ports + "\n```";
+    const std::string ret = render_syntax_node_text(sm, *proto.returnType);
+    return "```\nfunction " + ret + " " + name + formatted_ports + "\n```";
+}
+
 std::string uri_from_file_name(std::string_view file_name) {
     if (file_name.empty())
         return {};

--- a/src/syntax_index_shared.cpp
+++ b/src/syntax_index_shared.cpp
@@ -336,6 +336,13 @@ std::string render_syntax_node_text(const slang::SourceManager& sm,
     return trim_copy(std::move(text));
 }
 
+std::string base_class_lookup_name(std::string_view base_class) {
+    auto name = base_class.substr(0, base_class.find('#'));
+    if (const auto scope = name.rfind("::"); scope != std::string_view::npos)
+        name = name.substr(scope + 2);
+    return trim_copy(std::string(name));
+}
+
 std::string symbol_canonical(std::string_view kind, std::string_view scope, std::string_view name) {
     std::string result;
     if (scope.empty()) {

--- a/src/syntax_index_shared.hpp
+++ b/src/syntax_index_shared.hpp
@@ -19,6 +19,7 @@ namespace slang {
 class SourceManager;
 namespace syntax {
 class ExpressionSyntax;
+class FunctionPrototypeSyntax;
 class PropertyExprSyntax;
 class SyntaxTree;
 }
@@ -159,6 +160,13 @@ std::string render_syntax_token_text(const slang::SourceManager& sm,
                                      std::optional<slang::SourceRange>& last_macro_range);
 std::string render_syntax_node_text(const slang::SourceManager& sm,
                                     const slang::syntax::SyntaxNode& node);
+
+/// Render the hover/documentation signature block for a function or task
+/// prototype.  Shared so the closed-file shard and the open-buffer dynamic
+/// index produce byte-identical `ValueEntry::signature` text for the same
+/// declaration.
+std::string make_subroutine_signature(const slang::syntax::FunctionPrototypeSyntax& proto,
+                                      const std::string& name, const slang::SourceManager& sm);
 
 std::string symbol_canonical(std::string_view kind, std::string_view scope, std::string_view name);
 bool is_module_value_kind(std::string_view kind);

--- a/src/syntax_index_shared.hpp
+++ b/src/syntax_index_shared.hpp
@@ -168,6 +168,12 @@ std::string render_syntax_node_text(const slang::SourceManager& sm,
 std::string make_subroutine_signature(const slang::syntax::FunctionPrototypeSyntax& proto,
                                       const std::string& name, const slang::SourceManager& sm);
 
+/// Reduce a verbatim `extends` clause to the bare class name used as the
+/// `ClassEntry` key.  The clause is stored as written, so it may carry a
+/// package qualifier and parameter overrides (`extends cfg_pkg::base_cfg #(8)`)
+/// that no index is keyed by.
+std::string base_class_lookup_name(std::string_view base_class);
+
 std::string symbol_canonical(std::string_view kind, std::string_view scope, std::string_view name);
 bool is_module_value_kind(std::string_view kind);
 std::string canonical_type_name_from_text(std::string_view type);

--- a/tests/test_completion.cpp
+++ b/tests/test_completion.cpp
@@ -1491,6 +1491,33 @@ TEST_CASE("completion: MemberAccess includes inherited class members", "[complet
     CHECK(has_label(result, "child_depth"));
 }
 
+TEST_CASE("completion: MemberAccess inherits through a qualified parameterized base",
+          "[completion]") {
+    CompletionEngine engine;
+    Analyzer analyzer;
+    const std::string uri = "file:///tmp/completion_member_inherited_qualified.sv";
+    // The `extends` clause is indexed verbatim, so a package qualifier and
+    // parameter overrides must not hide the base class members.
+    const std::string text =
+        "package cfg_pkg;\n"
+        "    class base_cfg #(int W = 8);\n"
+        "        int base_depth;\n"
+        "    endclass\n"
+        "endpackage\n"
+        "class child_cfg extends cfg_pkg::base_cfg #(16);\n"
+        "    int child_depth;\n"
+        "endclass\n"
+        "module top;\n"
+        "    child_cfg cfg;\n"
+        "    initial cfg.\n"
+        "endmodule\n";
+    analyzer.open(uri, text);
+
+    auto result = complete_at(engine, analyzer, uri, 10, 16);
+    CHECK(has_label(result, "base_depth"));
+    CHECK(has_label(result, "child_depth"));
+}
+
 TEST_CASE("completion: MemberAccess includes interface signals and modports", "[completion]") {
     CompletionEngine engine;
     Analyzer analyzer;

--- a/tests/test_completion.cpp
+++ b/tests/test_completion.cpp
@@ -1518,6 +1518,29 @@ TEST_CASE("completion: MemberAccess inherits through a qualified parameterized b
     CHECK(has_label(result, "child_depth"));
 }
 
+TEST_CASE("completion: MemberAccess resolves a package-qualified declared type",
+          "[completion]") {
+    CompletionEngine engine;
+    Analyzer analyzer;
+    const std::string uri = "file:///tmp/completion_member_qualified_decl.sv";
+    // The qualifier sits on the variable declaration rather than on an
+    // `extends` clause, so the receiver's type must survive qualification.
+    const std::string text =
+        "package cfg_pkg;\n"
+        "    class base_cfg #(int W = 8);\n"
+        "        int base_depth;\n"
+        "    endclass\n"
+        "endpackage\n"
+        "module top;\n"
+        "    cfg_pkg::base_cfg #(16) cfg;\n"
+        "    initial cfg.\n"
+        "endmodule\n";
+    analyzer.open(uri, text);
+
+    auto result = complete_at(engine, analyzer, uri, 7, 16);
+    CHECK(has_label(result, "base_depth"));
+}
+
 TEST_CASE("completion: MemberAccess includes interface signals and modports", "[completion]") {
     CompletionEngine engine;
     Analyzer analyzer;

--- a/tests/test_definition.cpp
+++ b/tests/test_definition.cpp
@@ -771,6 +771,81 @@ TEST_CASE("definition: unresolvable identifier stays fast on a large project",
     std::filesystem::remove_all(dir);
 }
 
+TEST_CASE("definition: class member access walks the extends chain across files",
+          "[definition]") {
+    Analyzer analyzer;
+    const auto base_path = write_temp_sv("lazyverilog_definition_pkt_base.sv",
+                                         "class pkt_base;\n"
+                                         "    int depth;\n"
+                                         "\n"
+                                         "    function void apply();\n"
+                                         "    endfunction\n"
+                                         "endclass\n");
+    const std::string top_uri = "file:///tmp/lazyverilog_definition_pkt_child.sv";
+    analyzer.set_extra_files({base_path.string()});
+    analyzer.wait_for_background_index_idle();
+    analyzer.open(top_uri, "class pkt_child extends pkt_base;\n"
+                           "endclass\n"
+                           "\n"
+                           "module top;\n"
+                           "    pkt_child child;\n"
+                           "    initial begin\n"
+                           "        child.depth = 1;\n"
+                           "        child.apply();\n"
+                           "    end\n"
+                           "endmodule\n");
+
+    auto field = analyzer.definition_of(top_uri, 6, 15);
+    REQUIRE(field.has_value());
+    CHECK(field->uri == uri_from_path(base_path));
+    CHECK(field->line == 1);
+    CHECK(field->col == 8);
+
+    auto method = analyzer.definition_of(top_uri, 7, 15);
+    REQUIRE(method.has_value());
+    CHECK(method->uri == uri_from_path(base_path));
+    CHECK(method->line == 3);
+
+    std::filesystem::remove(base_path);
+}
+
+TEST_CASE("definition: unqualified inherited member inside a class body resolves to the base",
+          "[definition]") {
+    Analyzer analyzer;
+    const auto base_path = write_temp_sv("lazyverilog_definition_inherited_base.sv",
+                                         "class pkt_base;\n"
+                                         "    int depth;\n"
+                                         "endclass\n");
+    const std::string child_uri = "file:///tmp/lazyverilog_definition_inherited_child.sv";
+    analyzer.set_extra_files({base_path.string()});
+    analyzer.wait_for_background_index_idle();
+    analyzer.open(child_uri, "class pkt_child extends pkt_base;\n"
+                             "    function void bump();\n"
+                             "        depth = depth + 1;\n"
+                             "    endfunction\n"
+                             "endclass\n");
+
+    auto loc = analyzer.definition_of(child_uri, 2, 8);
+    REQUIRE(loc.has_value());
+    CHECK(loc->uri == uri_from_path(base_path));
+    CHECK(loc->line == 1);
+    CHECK(loc->col == 8);
+
+    // A method local of the same name still shadows the inherited member.
+    analyzer.open(child_uri, "class pkt_child extends pkt_base;\n"
+                             "    function void bump();\n"
+                             "        int depth;\n"
+                             "        depth = 1;\n"
+                             "    endfunction\n"
+                             "endclass\n");
+    auto shadowed = analyzer.definition_of(child_uri, 3, 8);
+    REQUIRE(shadowed.has_value());
+    CHECK(shadowed->uri == child_uri);
+    CHECK(shadowed->line == 2);
+
+    std::filesystem::remove(base_path);
+}
+
 TEST_CASE("definition: imported package subroutine resolves while the package file is open",
           "[definition]") {
     Analyzer analyzer;

--- a/tests/test_definition.cpp
+++ b/tests/test_definition.cpp
@@ -770,3 +770,43 @@ TEST_CASE("definition: unresolvable identifier stays fast on a large project",
 
     std::filesystem::remove_all(dir);
 }
+
+TEST_CASE("definition: imported package subroutine resolves while the package file is open",
+          "[definition]") {
+    Analyzer analyzer;
+    const auto pkg_path = write_temp_sv("lazyverilog_definition_open_pkg.sv",
+                                        "package common_pkg;\n"
+                                        "typedef int my_int_t;\n"
+                                        "\n"
+                                        "function void foo();\n"
+                                        "endfunction\n"
+                                        "endpackage\n");
+    const std::string pkg_uri = uri_from_path(pkg_path);
+    const std::string top_uri = "file:///tmp/lazyverilog_definition_open_pkg_top.sv";
+    analyzer.set_extra_files({pkg_path.string()});
+    analyzer.wait_for_background_index_idle();
+
+    // The package buffer being open routes the lookup through the dynamic
+    // open-file shard instead of the disk-backed one; both must report the
+    // declaration position.
+    analyzer.open(pkg_uri, "package common_pkg;\n"
+                           "typedef int my_int_t;\n"
+                           "\n"
+                           "function void foo();\n"
+                           "endfunction\n"
+                           "endpackage\n");
+    analyzer.open(top_uri, "module top;\n"
+                           "import common_pkg::*;\n"
+                           "    initial begin\n"
+                           "        foo();\n"
+                           "    end\n"
+                           "endmodule\n");
+
+    auto loc = analyzer.definition_of(top_uri, 3, 9);
+    REQUIRE(loc.has_value());
+    CHECK(loc->uri == pkg_uri);
+    CHECK(loc->line == 3);
+    CHECK(loc->col == 14);
+
+    std::filesystem::remove(pkg_path);
+}


### PR DESCRIPTION
Fixes four defects in class and package symbol lookup, found while investigating why go-to-definition on an inherited member did nothing.

Closes #31
Closes #32
Closes #33
Closes #34

## What was broken

**#31 — go-to-definition ignored the `extends` chain.** Member lookup matched only the object's exact declared class, so `child.depth` and a bare `depth` inside a child class body both returned nothing when the declaration lived on a base class. Completion already walked the chain, which is why `child.` listed members that go-to-def could not reach.

**#32 — package subroutines resolved to line 0.** The dynamic open-file shard left `ValueEntry` line/col unset for package functions and tasks, so an imported subroutine jumped to the top of the file whenever its package was also open in the editor. Closed-file lookups were correct, which is what made this look intermittent.

**#33 — completion dropped inherited members for a qualified base.** The `extends` clause is indexed verbatim, so `extends cfg_pkg::base_cfg #(8)` never matched a class entry.

**#34 — completion returned nothing for a qualified declared type.** `cfg_pkg::base_cfg cfg;` resolved the receiver's type to `cfg_pkg`, a package rather than a class, so not even the class's own members were offered.

## Approach

Class hierarchies routinely span files — a child in a live buffer extending a base in a closed project file — so `find_class_member_in_hierarchy()` re-searches every index shard at each `extends` hop, cycle-guarded.

For the unqualified in-class case, `DefinitionTargetVisitor` now tracks the enclosing class. The lookup deliberately sits **after** the current-file AST walk and **before** the project-wide generic scan: method locals and same-file declarations keep shadowing the base class, but a real inherited member still beats an unrelated same-named symbol elsewhere in the project. Both halves have assertions.

`make_fn_signature` moved to `syntax_index_shared` as `make_subroutine_signature()` so the open-buffer and closed-file shards emit identical entries for the same declaration.

## Performance

The #32 fix adds position and signature rendering to `build_current_ast_structural_index`, so I measured it against a synthetic package of 2000 package-level functions, best-of-20, three runs:

| config | best (ms) |
|---|---|
| before | 8.07 / 8.23 / 8.31 |
| line/col + kind | 8.25 / 8.34 / 8.40 |
| + signature | 11.76 |

Position data is free; the signature is the whole cost, and it is paid once per edit snapshot via `std::call_once`, not per request. Class methods go through a different branch, so realistic buffers have tens of package-level subroutines rather than thousands. Project startup indexing is untouched — it already did this work.

## Testing

`ctest`: 473/473 pass. Five new regression tests, each confirmed non-vacuous by stashing `src/` and watching it fail against the old code. Every commit was built and run through the full suite in isolation, so each one compiles on its own.

Demo fixtures under `demo/` reproduce all four cases by hand.

## Not addressed

`src/analyzer.cpp` has a pre-existing unused `name_text()` — dead at `main` too, left alone.