### PR TITLE
Add SessionStart hook to provision nvim + build for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SessionStart hook: makes a modern Neovim + the built lazyverilog-lsp binary
+# available in Claude Code on the web sessions, so the nvim plugin (which
+# needs Neovim >= 0.10 for vim.lsp.get_clients) can be exercised against a
+# real, freshly-built LSP server.
+#
+# Local/CLI sessions are left untouched — a developer's own machine already
+# has whatever nvim/build setup they use.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+REPO_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+NVIM_MIN_MAJOR=0
+NVIM_MIN_MINOR=10
+NVIM_INSTALL_DIR="/opt/nvim-linux-x86_64"
+NVIM_BIN="$NVIM_INSTALL_DIR/bin/nvim"
+
+nvim_version_ok() {
+  command -v nvim >/dev/null 2>&1 || return 1
+  local ver major minor
+  ver=$(nvim --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  major=$(echo "$ver" | cut -d. -f1)
+  minor=$(echo "$ver" | cut -d. -f2)
+  [ "$major" -gt "$NVIM_MIN_MAJOR" ] && return 0
+  [ "$major" -eq "$NVIM_MIN_MAJOR" ] && [ "$minor" -ge "$NVIM_MIN_MINOR" ]
+}
+
+if ! nvim_version_ok; then
+  echo "[session-start] installing Neovim (>= 0.${NVIM_MIN_MINOR}) for the lazyverilog nvim plugin"
+  tmp_tarball="$(mktemp -d)/nvim-linux-x86_64.tar.gz"
+  curl -fsSL -o "$tmp_tarball" \
+    https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
+  rm -rf "$NVIM_INSTALL_DIR"
+  mkdir -p "$NVIM_INSTALL_DIR"
+  tar xzf "$tmp_tarball" -C "$(dirname "$NVIM_INSTALL_DIR")"
+  ln -sf "$NVIM_BIN" /usr/local/bin/nvim
+  rm -rf "$(dirname "$tmp_tarball")"
+fi
+
+echo "[session-start] $(nvim --version | head -1)"
+
+echo "[session-start] configuring + building lazyverilog-lsp"
+cmake -B "$REPO_DIR/build" -DCMAKE_BUILD_TYPE=Release -S "$REPO_DIR"
+cmake --build "$REPO_DIR/build" -j"$(nproc)" --target lazyverilog-lsp
+
+echo "[session-start] done: $REPO_DIR/build/lazyverilog-lsp"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `.claude/hooks/session-start.sh` hook that provisions nvim and builds `lazyverilog-lsp` on session resume/start for Claude Code on the web
- Wire the hook up via `.claude/settings.json`

## Test plan
- [x] Verified the hook runs successfully on session start/resume (build output confirms `lazyverilog-lsp` built and nvim configured)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VU75RkrB5RCe5xnHJACDYv)_