### PR TITLE
Set up nvim-mcp so Claude can drive a running Neovim instance

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -47,3 +47,18 @@ cmake -B "$REPO_DIR/build" -DCMAKE_BUILD_TYPE=Release -S "$REPO_DIR"
 cmake --build "$REPO_DIR/build" -j"$(nproc)" --target lazyverilog-lsp
 
 echo "[session-start] done: $REPO_DIR/build/lazyverilog-lsp"
+
+# nvim-mcp gives Claude an MCP server that can drive a running Neovim
+# instance (buffers, diagnostics, RPC) instead of only shelling out to nvim
+# headlessly. The server is registered project-wide via .mcp.json (trusted
+# automatically by .claude/settings.json's enableAllProjectMcpServers), but
+# the `nvim-mcp` binary itself isn't part of the repo, so each fresh
+# container needs it built.
+if command -v nvim-mcp >/dev/null 2>&1; then
+  echo "[session-start] nvim-mcp already installed: $(command -v nvim-mcp)"
+elif command -v cargo >/dev/null 2>&1; then
+  echo "[session-start] installing nvim-mcp (cargo install nvim-mcp)"
+  cargo install nvim-mcp
+else
+  echo "[session-start] WARNING: cargo not found, skipping nvim-mcp install" >&2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "enableAllProjectMcpServers": true,
   "hooks": {
     "SessionStart": [
       {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "nvim": {
+      "type": "stdio",
+      "command": "nvim-mcp",
+      "args": [
+        "--connect",
+        "auto"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Register the `nvim-mcp` MCP server (project-scoped, via `.mcp.json`) so Claude can drive a running Neovim instance (buffers, diagnostics, RPC) instead of only shelling out to `nvim` headlessly.
- Auto-trust the server via `enableAllProjectMcpServers: true` in `.claude/settings.json` so no interactive approval is needed.
- Extend the `SessionStart` hook to build the `nvim-mcp` binary (`cargo install nvim-mcp`) on every fresh remote session, alongside the existing nvim/`lazyverilog-lsp` provisioning.

## Test plan
- [x] Verified `cargo install nvim-mcp` builds cleanly in the remote session environment
- [x] Verified `claude mcp add -s project nvim -- nvim-mcp --connect auto` produces the intended `.mcp.json`
- [x] Validated `.claude/settings.json`, `.mcp.json` JSON syntax and hook script shell syntax
- [ ] Exercise `nvim-mcp` against a live Neovim instance in a fresh session (not yet done — MCP servers only load at session start)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RGba8cB5SiA5mszAK7Nt8J)_