### PR TITLE
fix: scope loop/block declarations in go-to-def and stray space before index bracket

### DIFF
--- a/src/analyzer.cpp
+++ b/src/analyzer.cpp
@@ -1413,10 +1413,45 @@ struct GenericDefinitionVisitor : public slang::syntax::SyntaxVisitor<GenericDef
         return false;
     }
 
+    // Lexical declaration scopes (begin/end blocks, loop headers) that enclose
+    // the declarations being visited.  A pair of zero lines means "no lexical
+    // restriction" — used for scopes that live in another file, where the
+    // cursor's line number is not comparable.
+    std::vector<std::pair<int, int>> scope_stack;
+
+    void push_scope(slang::SourceRange range) {
+        if (!range.start().valid() || !range.end().valid() ||
+            uri_from_source_location(sm, range.start()) != uri) {
+            scope_stack.emplace_back(0, 0);
+            return;
+        }
+        scope_stack.emplace_back((int)sm.getLineNumber(range.start()),
+                                 (int)sm.getLineNumber(range.end()));
+    }
+
+    // A declaration inside a block or loop header is only visible to uses
+    // lexically inside that same block:
+    //
+    //     for (int i = 0; i < 10; i++) begin ... end
+    //     for (int i = 0; i < 10; i++) begin o_data[i] = 1; end
+    //                                               ^ the second `i`, not the first
+    bool cursor_in_innermost_scope() const {
+        if (scope_stack.empty())
+            return true;
+        const auto [start_line, end_line] = scope_stack.back();
+        if (start_line > 0 && use_line_one_based < start_line)
+            return false;
+        if (end_line > 0 && use_line_one_based > end_line)
+            return false;
+        return true;
+    }
+
     void maybe_set(slang::parsing::Token token, bool scope_sensitive = true) {
         if (!token || token.valueText() != name)
             return;
         if (!package_member_visible(current_package, token.valueText()))
+            return;
+        if (scope_sensitive && !cursor_in_innermost_scope())
             return;
 
         auto loc = location_from_token_actual_uri(sm, uri, token);
@@ -1516,6 +1551,24 @@ struct GenericDefinitionVisitor : public slang::syntax::SyntaxVisitor<GenericDef
     void handle(const slang::syntax::TypedefDeclarationSyntax& node) {
         maybe_set(node.name);
         visitDefault(node);
+    }
+
+    void handle(const slang::syntax::BlockStatementSyntax& node) {
+        push_scope(node.sourceRange());
+        visitDefault(node);
+        scope_stack.pop_back();
+    }
+
+    void handle(const slang::syntax::ForLoopStatementSyntax& node) {
+        push_scope(node.sourceRange());
+        visitDefault(node);
+        scope_stack.pop_back();
+    }
+
+    void handle(const slang::syntax::ForeachLoopStatementSyntax& node) {
+        push_scope(node.sourceRange());
+        visitDefault(node);
+        scope_stack.pop_back();
     }
 };
 

--- a/src/features/formatter_passes.hpp
+++ b/src/features/formatter_passes.hpp
@@ -998,7 +998,14 @@ public:
                 in_covergroup = false;
         }
         size_t stmt_start = 0;
+        int stmt_pd = 0;
         for (size_t i = 0; i < tokens.size(); ++i) {
+            if (kind_is(tokens[i], TK::OpenParenthesis)) ++stmt_pd;
+            else if (kind_is(tokens[i], TK::CloseParenthesis)) stmt_pd = std::max(0, stmt_pd - 1);
+            // `for (int i = 0; i < n; i++)` — the header separators live inside
+            // the parens and do not end the enclosing statement.
+            if (kind_is(tokens[i], TK::Semicolon) && stmt_pd > 0)
+                continue;
             if (kind_is(tokens[i], TK::Semicolon) || kind_is(tokens[i], TK::Comma)) {
                 for (size_t j = stmt_start; j <= i && j < tokens.size(); ++j) { tokens[j].immutable.syntax.stmt_begin = stmt_start; tokens[j].immutable.syntax.stmt_end = i; }
                 stmt_start = i + 1;

--- a/tests/test_definition.cpp
+++ b/tests/test_definition.cpp
@@ -1293,3 +1293,55 @@ TEST_CASE("hover: T::type_id::create describes the alias target's method",
     CHECK(info->doc.find("function registry_base create") != std::string::npos);
     CHECK(info->doc.find("int parent") != std::string::npos);
 }
+
+TEST_CASE("definition: loop variable resolves to its own for-loop declaration",
+          "[definition][scope]") {
+    Analyzer analyzer;
+    const std::string uri = "file:///tmp/lazyverilog_for_loop_scope.sv";
+    analyzer.open(uri,
+                  "module m;\n"
+                  "always_comb begin\n"
+                  "    for (int i = 0; i < 10; i++) begin\n"
+                  "        o_data[i] = 1;\n"
+                  "    end\n"
+                  "\n"
+                  "    for (int i = 0; i < 10; i++) begin\n"
+                  "        address[i] = 1;\n"
+                  "    end\n"
+                  "end\n"
+                  "endmodule\n");
+
+    auto first = analyzer.definition_of(uri, 3, 15);
+    REQUIRE(first.has_value());
+    CHECK(first->line == 2);
+    CHECK(first->col == 13);
+
+    auto second = analyzer.definition_of(uri, 7, 16);
+    REQUIRE(second.has_value());
+    CHECK(second->line == 6);
+    CHECK(second->col == 13);
+}
+
+TEST_CASE("definition: block-local declaration does not shadow a later sibling block",
+          "[definition][scope]") {
+    Analyzer analyzer;
+    const std::string uri = "file:///tmp/lazyverilog_block_scope.sv";
+    analyzer.open(uri,
+                  "module m;\n"
+                  "always_comb begin\n"
+                  "    begin\n"
+                  "        int tmp;\n"
+                  "        tmp = 1;\n"
+                  "    end\n"
+                  "    begin\n"
+                  "        int tmp;\n"
+                  "        tmp = 2;\n"
+                  "    end\n"
+                  "end\n"
+                  "endmodule\n");
+
+    auto loc = analyzer.definition_of(uri, 8, 8);
+    REQUIRE(loc.has_value());
+    CHECK(loc->line == 7);
+}
+

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -4601,3 +4601,25 @@ TEST_CASE("formatter: array subscript with identifier index aligned with group",
     CHECK(format_source(src, opts) == expected);
     CHECK(format_source(expected, opts) == expected);
 }
+
+TEST_CASE("formatter: index bracket inside a for body keeps no space before the bracket",
+          "[formatter]") {
+    FormatOptions opts;
+    opts.default_indent_level_inside_outmost_block = 0;
+    opts.indent_size = 4;
+
+    CHECK(format_source("module m;\n"
+                        "always_comb begin\n"
+                        "    for (int i = 0; i < 10; i++) begin\n"
+                        "        o_data[i] = 1;\n"
+                        "    end\n"
+                        "end\n"
+                        "endmodule\n",
+                        opts) == "module m;\n"
+                                 "always_comb begin\n"
+                                 "    for (int i = 0; i < 10; i++) begin\n"
+                                 "        o_data[i] = 1;\n"
+                                 "    end\n"
+                                 "end\n"
+                                 "endmodule\n");
+}


### PR DESCRIPTION
Closes #69

## go-to-definition on a loop variable

`GenericDefinitionVisitor` (`src/analyzer.cpp`) matched declarators by name only and kept the first hit, with no lexical scope filter. Go-to-definition on the `i` in the second `for` loop landed on the `int i` of the first loop; two sibling `begin`/`end` blocks declaring the same name had the same problem.

The visitor now keeps a scope stack pushed on `BlockStatementSyntax`, `ForLoopStatementSyntax`, and `ForeachLoopStatementSyntax`. `maybe_set()` skips a declaration whose innermost enclosing scope does not contain the cursor line. A scope that lives in another file pushes `{0, 0}` (no restriction), because the cursor's line number is not comparable across files.

## Stray space before an index bracket inside a for body

`o_data[i] = 1;` inside a `for` body formatted as `o_data [i] = 1;`. Statement boundaries (`stmt_begin` / `stmt_end`, `src/features/formatter_passes.hpp`) split on every `;` and `,`, including the two separators inside `for (int i = 0; i < 10; i++)`, so the statement's `stmt_begin` pointed into the loop header and `is_var_declaration_trailing_dimension_open()` misclassified the index as an unpacked declaration dimension.

Semicolons at paren depth > 0 no longer end a statement. Commas are untouched, since port and argument lists rely on the current behavior.

## Verification

- `ctest --test-dir build` — 558/558 pass, including three new regression tests (two in `tests/test_definition.cpp`, one in `tests/test_formatter.cpp`).
- Format sweep over `tests/rtl/{ibex,cva6,caliptra-rtl}` — 2468 files, all pass and idempotent.

## Not covered

Go-to-definition on a `genvar` in a generate-for returns nothing at all — `LoopGenerateSyntax` never exposes its identifier as a definition candidate. That is a separate gap, left for its own change.